### PR TITLE
Feat: Add JSON & YAML outputs for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ go build .
 
 ## Usage
 1. Download any Helm Chart. You will reference it later on.
-2. Run as `./helm-decomposer -chart mychart.tgz -i -o`
+2. Run as `./helm-decomposer -chart mychart.tgz -ij -o`
 ```
 ❯ ./helm-decomposer -h
 Usage of ./helm-decomposer:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Usage of ./helm-decomposer:
         Helm Chart to process. Submit tar.gz or folder name. (default "samples/nginx")
   -i    Inspect images used in the Helm Chart. (default "false")
   -o    Write output to helm-decomposer-output.md. (default "false")
+  -j    Write output to images.json. (default \"false\"")
+  -y    Write output to images.yaml. (default \"false\"")
 ```
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ go build .
 Usage of ./helm-decomposer:
   -chart string
         Helm Chart to process. Submit tar.gz or folder name. (default "samples/nginx")
-  -i    Inspect images used in the Helm Chart. (default "false")
-  -o    Write output to helm-decomposer-output.md. (default "false")
-  -j    Write output to images.json. (default \"false\"")
-  -y    Write output to images.yaml. (default \"false\"")
+  -o     Write output to helm-decomposer-output.md. (default "false")
+  -ij    Write output to images.json. (default "false")
+  -iy    Write output to images.yaml. (default "false")
 ```
 
 ## Issues

--- a/images.go
+++ b/images.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"encoding/json"
-    	"os"
 )
 
 func unique(strSlice []string) []string {
@@ -21,7 +19,7 @@ func unique(strSlice []string) []string {
 	return list
 }
 
-func detectImages(m map[string]string) {
+func detectImages(m map[string]string) []string{
 	fmt.Println("\n--- Searching images in K8S manifests ---")
 	// Populate keys (filenames)
 	keys := make([]string, 0, len(m))
@@ -69,20 +67,5 @@ func detectImages(m map[string]string) {
 		fmt.Println("\u2192", i)
 	}
 
-	imageDict := map[string][]string{"images": uniqueImageList}
-
-	jsonFile, err := os.Create("images.json")
-    	if err != nil {
-		fmt.Println(err)
-		return
-    	}
-    	defer jsonFile.Close()
-
-    	encoder := json.NewEncoder(jsonFile)
-    	err = encoder.Encode(imageDict)
-    	if err != nil {
-		fmt.Println(err)
-		return
-    	}
-
+	return uniqueImageList
 }

--- a/images.go
+++ b/images.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"encoding/json"
+    	"os"
 )
 
 func unique(strSlice []string) []string {
@@ -66,5 +68,21 @@ func detectImages(m map[string]string) {
 	for _, i := range uniqueImageList {
 		fmt.Println("\u2192", i)
 	}
+
+	imageDict := map[string][]string{"images": uniqueImageList}
+
+	jsonFile, err := os.Create("images.json")
+    	if err != nil {
+		fmt.Println(err)
+		return
+    	}
+    	defer jsonFile.Close()
+
+    	encoder := json.NewEncoder(jsonFile)
+    	err = encoder.Encode(imageDict)
+    	if err != nil {
+		fmt.Println(err)
+		return
+    	}
 
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"encoding/json"
+	"gopkg.in/yaml.v3"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -19,6 +21,8 @@ func main() {
 	flagInputChart := flag.String("chart", "sample-helm-charts/nginx", "Helm Chart to process. Submit .tgz or folder name.")
 	flagOutputFile := flag.Bool("o", false, "Write output to helm-decomposer-output.md. (default \"false\")")
 	flagDetectImages := flag.Bool("i", false, "Inspect images used in the Helm Chart. (default \"false\")")
+	flagGenerateJson := flag.Bool("j",false, "Write output to images.json. (default \"false\"")
+	flagGenerateYaml := flag.Bool("y",false, "Write output to images.yaml. (default \"false\"")
 
 	flag.Parse()
 
@@ -54,7 +58,45 @@ func main() {
 	}
 
 	if *flagDetectImages {
-		detectImages(m)
+		// use uniqueImageList from images.go to generate JSON & YAML
+		uniqueImageList := detectImages(m)
+
+		// generate json from the list of images obtained from DetectImages
+		if *flagGenerateJson {
+			imageDict := map[string][]string{"images": uniqueImageList}
+			// write to file images.json
+			jsonFile, err := os.Create("images.json")
+    		if err != nil {
+        		fmt.Println(err)
+        		return
+    		}
+    		defer jsonFile.Close()
+
+    		encoder := json.NewEncoder(jsonFile)
+    		err = encoder.Encode(imageDict)
+    		if err != nil {
+        		fmt.Println(err)
+        		return
+    		}
+		}
+		// generate Yaml from the list of images obtained from DetectImages
+		if *flagGenerateYaml {
+			imageDict := map[string][]string{"images": uniqueImageList}
+			// write to file images.yaml
+			yamlFile, err := os.Create("images.yaml")
+    		if err != nil {
+        		fmt.Println(err)
+        		return
+    		}
+    		defer yamlFile.Close()
+
+    		encoder := yaml.NewEncoder(yamlFile)
+    		err = encoder.Encode(imageDict)
+    		if err != nil {
+        		fmt.Println(err)
+        		return
+    		}
+		}
 	}
 
 	fmt.Printf("\n--- Building Tree for the Helm Chart \"%s\" ---\n\n", loadedChart.Name())

--- a/main.go
+++ b/main.go
@@ -20,9 +20,8 @@ func main() {
 
 	flagInputChart := flag.String("chart", "sample-helm-charts/nginx", "Helm Chart to process. Submit .tgz or folder name.")
 	flagOutputFile := flag.Bool("o", false, "Write output to helm-decomposer-output.md. (default \"false\")")
-	flagDetectImages := flag.Bool("i", false, "Inspect images used in the Helm Chart. (default \"false\")")
-	flagGenerateJson := flag.Bool("j",false, "Write output to images.json. (default \"false\"")
-	flagGenerateYaml := flag.Bool("y",false, "Write output to images.yaml. (default \"false\"")
+	flagGenerateJson := flag.Bool("ij", false, "Write output to images.json. (default \"false\")")
+	flagGenerateYaml := flag.Bool("iy", false, "Write output to images.yaml. (default \"false\")")
 
 	flag.Parse()
 
@@ -57,46 +56,53 @@ func main() {
 		fmt.Println("\nWARNING: Helm Chart can not be fully templated. Please check values files on all levels, usage of aliases, etc...")
 	}
 
-	if *flagDetectImages {
+	// generate json from the list of images obtained from DetectImages
+	if *flagGenerateJson {
+		
 		// use uniqueImageList from images.go to generate JSON & YAML
 		uniqueImageList := detectImages(m)
-
-		// generate json from the list of images obtained from DetectImages
-		if *flagGenerateJson {
-			imageDict := map[string][]string{"images": uniqueImageList}
-			// write to file images.json
-			jsonFile, err := os.Create("images.json")
-    		if err != nil {
-        		fmt.Println(err)
-        		return
-    		}
-    		defer jsonFile.Close()
-
-    		encoder := json.NewEncoder(jsonFile)
-    		err = encoder.Encode(imageDict)
-    		if err != nil {
-        		fmt.Println(err)
-        		return
-    		}
+		imageDict := map[string][]string{"images": uniqueImageList}
+		
+		fmt.Printf("\n--- Generating image list as JSON ---")
+		// write to file images.json
+		jsonFile, err := os.Create("images.json")
+		if err != nil {
+			fmt.Println(err)
+			return
 		}
-		// generate Yaml from the list of images obtained from DetectImages
-		if *flagGenerateYaml {
-			imageDict := map[string][]string{"images": uniqueImageList}
-			// write to file images.yaml
-			yamlFile, err := os.Create("images.yaml")
-    		if err != nil {
-        		fmt.Println(err)
-        		return
-    		}
-    		defer yamlFile.Close()
+		defer jsonFile.Close()
 
-    		encoder := yaml.NewEncoder(yamlFile)
-    		err = encoder.Encode(imageDict)
-    		if err != nil {
-        		fmt.Println(err)
-        		return
-    		}
+		encoder := json.NewEncoder(jsonFile)
+		err = encoder.Encode(imageDict)
+		if err != nil {
+			fmt.Println(err)
+			return
 		}
+		fmt.Printf("\n--- File saved to images.json ---")
+	}
+
+	// generate Yaml from the list of images obtained from DetectImages
+	if *flagGenerateYaml {
+		// use uniqueImageList from images.go to generate JSON & YAML
+		uniqueImageList := detectImages(m)
+		imageDict := map[string][]string{"images": uniqueImageList}
+		
+		fmt.Printf("\n--- Generating image list as YAML ---")
+		// write to file images.yaml
+		yamlFile, err := os.Create("images.yaml")
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		defer yamlFile.Close()
+
+		encoder := yaml.NewEncoder(yamlFile)
+		err = encoder.Encode(imageDict)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		fmt.Printf("\n--- File saved to images.yaml ---")
 	}
 
 	fmt.Printf("\n--- Building Tree for the Helm Chart \"%s\" ---\n\n", loadedChart.Name())


### PR DESCRIPTION
# Adds support for generating YAML & JSON outputs for images

## Validations

### Helm Charts

> helm search repo nginx-stable/nginx-ingress

```
NAME                            CHART VERSION   APP VERSION     DESCRIPTION             
nginx-stable/nginx-ingress      0.18.0          3.2.0           NGINX Ingress Controller
```
> helm pull nginx-stable/nginx-ingress

### Helm Decomposer Outputs

```
helm-decomposer -chart nginx-ingress/ -i -j -y

Loading Helm Chart "nginx-ingress/"...

--- Searching images in K8S manifests ---

Image found in nginx-ingress/templates/controller-deployment.yaml...
nginx/nginx-ingress:3.2.0

--- List of unique Docker images in the Helm Chart ---

→ nginx/nginx-ingress:3.2.0

--- Building Tree for the Helm Chart "nginx-ingress" ---

╴ nginx-ingress
```

#### images.json

```
{"images":["nginx/nginx-ingress:3.2.0"]}
```

#### images.yaml

```
images:
    - nginx/nginx-ingress:3.2.0
```
